### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://volleynerd2.visualstudio.com/27321f3e-ef03-4abe-9e18-b221e8ee6548/df13f7a7-b5a5-4eee-a37f-3f316f4c3211/_apis/work/boardbadge/0368c28a-1706-4e00-b7f1-c945430b0822)](https://volleynerd2.visualstudio.com/27321f3e-ef03-4abe-9e18-b221e8ee6548/_boards/board/t/df13f7a7-b5a5-4eee-a37f-3f316f4c3211/Microsoft.RequirementCategory)
 [![Build Status](https://volleynerd2.visualstudio.com/Learning/_apis/build/status/volleynerd.ContosoAir?branchName=master)](https://volleynerd2.visualstudio.com/Learning/_build/latest?definitionId=3&branchName=master)
 
 # This project is retired, archived, and no longer supported. You are welcome to continue to use and fork the repository.


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#861](https://volleynerd2.visualstudio.com/27321f3e-ef03-4abe-9e18-b221e8ee6548/_workitems/edit/861). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.